### PR TITLE
Establish first-cut functionality (key-value only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ DerivedData/
 .DS_Store
 db.sqlite
 .swiftpm
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+Packages
+Package.resolved
+.build
+xcuserdata
+*.xcodeproj
+DerivedData/
+.DS_Store
+db.sqlite
+.swiftpm
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:5.3
+/**
+ * Copyright (c) 2021-present, Joshua Auerbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PackageDescription
+
+let package = Package(
+    name: "nimbella-sdk",
+    products: [
+        .library(name: "nimbella-sdk", targets: ["nimbella-sdk"])
+    ],
+    dependencies: [
+        .package(url: "https://gitlab.com/mordil/RediStack.git", .branch("master"))
+        // storage client dependencies to be added later
+    ],
+    targets: [
+        .target(name: "nimbella-sdk", dependencies: ["RediStack"]),
+        .testTarget(name: "nimbella-sdk-tests", dependencies: ["nimbella-sdk"])
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 
 let package = Package(
     name: "nimbella-sdk",
-    platforms: [.iOS("13.0")], // Doesn't typically run on iOS but this avoids some Swift error messages
+    platforms: [.iOS("13.0"), .macOS("10.15")],
     products: [
         .library(name: "nimbella-sdk", targets: ["nimbella-sdk"])
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ import PackageDescription
 
 let package = Package(
     name: "nimbella-sdk",
+    platforms: [.iOS("13.0")], // Doesn't typically run on iOS but this avoids some Swift error messages
     products: [
         .library(name: "nimbella-sdk", targets: ["nimbella-sdk"])
     ],

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Nimbella SDK for Swift
 
-A Swift package to interact to interact with nimbella.com services.
+A Swift package to interact to interact with [nimbella.com](https://nimbella.com) services.
 
 This SDK is under construction.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,55 @@ A Swift library to interact with [`nimbella.com`](https://nimbella.com) services
 
 ## Installation
 
-Coming soon...
+- `macOS` 10.15 and XCode 12 is assumed in the following.
+
+- In `Package.swift`:
+
+```swift
+let package = Package(
+    ...
+    dependencies: [
+       .package(url: "https://github.com/nimbella/nimbella-sdk-swift.git", .branch("master"), name: NimbellaSDK)
+       ...
+    ],
+    ...
+)
+```
+- When XCode is open on the resulting project, the package manager should incorporate the dependency automatically as needed.
 
 ## Usage
 
-Coming soon...
+```swift
+import NimbellaSDK
+import RediStack
+
+class ...
+    func testRedis() {
+        do {
+            let redisClient = try redis()
+            try redisClient.set("foo", to: "bar").wait()
+            ...
+            let result = try redisClient.get("foo").wait()?.string
+            ...  
+            let deleted = try redisClient.delete(["foo"]).wait()
+            ...
+            let newResult = try redisClient.get("foo").wait()
+            ...
+        } catch {
+            ...
+        }
+    }
+    func testStorage() {
+        do {
+            let storageClient = try storageClient(false)
+        } catch {
+            // Currently throws NimbellaError.notImplemented
+        }
+    }
+}
+```
+
+Object store support is coming soon.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Swift library to interact with [`nimbella.com`](https://nimbella.com) services
 
 ## Installation
 
+_As of this writing, the Nimbella Swift runtime has maximum version 4.2 whereas this SDK requires 5.3.  So, this SDK is not yet operational for its intended purpose.  There is a plan to resolve this.  This package can be installed locally and tested with local redis instances meanwhile._
+
 - `macOS` 10.15 and XCode 12 is assumed in the following.
 
 - In `Package.swift`:
@@ -19,6 +21,8 @@ let package = Package(
 )
 ```
 - When XCode is open on the resulting project, the package manager should incorporate the dependency automatically as needed.
+
+- To develop without using XCode, use `swift build`, `swift package` etc. as per Swift Package Manager documentation.
 
 ## Usage
 
@@ -52,7 +56,21 @@ class ...
 }
 ```
 
-Object store support is coming soon.
+You can lightly exercise this functionality using `swift test`.
+
+## Notes
+
+The purpose of the SDK is to support key-value storage and object storage for code running in serverless functions ("actions") in the Nimbella stack.  Usage in other contexts is possible but may require understanding limitations that come from the original design point.
+
+To use the code in Nimbella actions, the Swift package manager root directory (containing `Package.swift` and `Sources`) must be deployed using the Nimbella [deployer](https://docs.nimbella.com/deployer-overview), specifying [_remote build_](https://docs.nimbella.com/building#remote-builds).
+
+#### Key-Value
+
+Key-value storage in Nimbella is provided via `redis` instances.  Redis support is provided via the [`RediStack` client](https://gitlabhttps://github.com/Mordil/RediStack).  The Nimbella SDK adds support for Nimbella's internal authentication conventions.   To use the code outside of a Nimbella action, set the environment variables `__NIM_REDIS_IP` and `__NIM_REDIS_PASSWORD` as in the unit tests of this package.  It is not possible to use the Nimbella client with a redis instance that does not require a password.  In that situation it is more straightforward to use the `RediStack` client directly.
+
+#### Object store
+
+Object store support is not present at this time but the intended interface is present in `StorageInterface.swift`.   Attempting to initiate object store access will cause `NimbellaError.notImplemented` to be thrown.   Adding working object store support is a future objective.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# -nimbella-sdk-swift-
+# Nimbella SDK for Swift
+
+A Swift package to interact to interact with nimbella.com services.
+
+This SDK is under construction.

--- a/Sources/nimbella-sdk/Nimbella.swift
+++ b/Sources/nimbella-sdk/Nimbella.swift
@@ -20,17 +20,17 @@
 import RediStack
 
 // Errors that can occur.
-enum NimbellaError : Error {
+public enum NimbellaError : Error {
     case notImplemented
     // TODO
 }
 
 // Retrieve a redis client handle
-public func redis() throws -> RedisConnection {
+public func redis() throws -> RedisClient {
     throw NimbellaError.notImplemented
 }
 
-// Retrieve a storageClient handlel
+// Retrieve a storageClient handle
 public func storageClient(_ web: Bool) throws -> StorageClient {
     throw NimbellaError.notImplemented
 }

--- a/Sources/nimbella-sdk/Nimbella.swift
+++ b/Sources/nimbella-sdk/Nimbella.swift
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2021-present, Joshua Auerbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The primary entry point to the Nimbella SDK.  Has 'redis' and 'storageClient
+// functions as in other SDKs.
+
+import RediStack
+
+// Errors that can occur.
+enum NimbellaError : Error {
+    case notImplemented
+    // TODO
+}
+
+// Retrieve a redis client handle
+public func redis() throws -> RedisConnection {
+    throw NimbellaError.notImplemented
+}
+
+// Retrieve a storageClient handlel
+public func storageClient(_ web: Bool) throws -> StorageClient {
+    throw NimbellaError.notImplemented
+}

--- a/Sources/nimbella-sdk/StorageInterface.swift
+++ b/Sources/nimbella-sdk/StorageInterface.swift
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2021-present, Joshua Auerbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import Combine
+
+// Model the StorageKey type that is to be stored in the credential store.  Only the 'provider' member has
+// specified semantics.  The rest is at the convenience of the provider.
+public protocol StorageKey {
+    var provider: String? { get }
+}
+
+// Metadata that can be set on a file
+public protocol SettableFileMetadata {
+    var contentType: String? { get set }
+    var cacheControl: String? { get set }
+}
+
+// Options that may be passed to deleteFiles
+public protocol DeleteFilesOptions {
+    var force: Bool? { get set }
+    var prefix: String? { get set }
+}
+
+// Options that may be passed to upload
+public protocol UploadOptions {
+    var destination: String? { get set }
+    var gzip: Bool? { get set }
+    var metadata: SettableFileMetadata? { get set }
+}
+
+// Options that may be passed to getFiles
+public protocol GetFilesOptions {
+    var prefix: String? { get set }
+}
+
+// Options that may be passed to save
+public protocol SaveOptions {
+    var metadata: SettableFileMetadata? { get set }
+}
+
+// Options that may be passed to download
+public protocol DownloadOptions {
+    var destination: String? { get set }
+}
+
+// Types used with signed URLs
+public enum SignedUrlVersion: String {
+    case v2 = "v2"
+    case v4 = "v4"
+}
+public enum SignedUrlAction: String {
+    case read = "read"
+    case write = "write"
+    case delete = "delete"
+}
+
+// Options that may be passed to getSignedUrl
+public protocol SignedUrlOptions {
+    var version: SignedUrlVersion { get set }
+    var action: SignedUrlAction { get set }
+    var expires: Int { get set }
+    var contentType: String? { get set }
+}
+
+// Options for setting website characteristics
+public protocol WebsiteOptions {
+    var mainPageSuffix: String? { get set }
+    var notFoundPage: String? { get set }
+}
+
+// Per object (file) metadata
+public protocol FileMetadata {
+    var name: String { get set }
+    var storageClass: String? { get set }
+    var size: String { get set }
+    var etag: String? { get set }
+    var updated: String? { get set }
+}
+
+// The behaviors required of a file handle (part of storage provider)
+public protocol RemoteFile {
+    // The name of the file
+    var name: String { get }
+    // Save data into the file
+    func save(data: Data, options: SaveOptions) -> Future<Void, Error>
+    // Set the file metadata
+    func setMetadata(meta: SettableFileMetadata) -> Future<Void, Error>
+    // Get the file metadata
+    func getMetadata() -> Future<FileMetadata, Error>
+    // Test whether file exists
+    func exists() -> Future<Bool, Error>
+    // Delete the file
+    func delete() -> Future<Void, Error>
+    // Obtain the contents of the file
+    func download(options: DownloadOptions?) -> Future<Data, Error>
+    // Get a signed URL to the file
+    func getSignedUrl(options: SignedUrlOptions) -> Future<String, Error>
+    // Get the underlying implementation for provider-dependent operations
+    func getImplementation() -> AnyObject
+}
+
+// The behaviors required of a storage client (part of storage provider)
+public protocol StorageClient {
+    // Get the root URL if the client is for web storage (return falsey for data storage)
+    func getURL() -> String
+    // Set website information
+    func setWebsite(website: WebsiteOptions) -> Future<Void, Error>
+    // Delete files from the store
+    func deleteFiles(options: DeleteFilesOptions?) -> Future<Void, Error>
+    // Add a local file (specified by path)
+    func upload(path: String, options: UploadOptions?) -> Future<Void, Error>
+    // Obtain a file handle in the store.  The file may or may not exist
+    func file(destination: String) -> RemoteFile
+    // Get files from the store
+    func getFiles(options: GetFilesOptions?) -> Future<[RemoteFile], Error>
+    // Get the underlying implementation for provider-dependent operations
+    func getImplementation() -> AnyObject
+}
+
+// The top-level signature of a storage provider
+public protocol StorageProvider {
+    // Provide the appropriate client handle for accessing a type file store (web or data) in a particular namespace
+    func getClient(namespace: String, apiHost: String, web: Bool, credentials: StorageKey) -> StorageClient
+    // Convert an object containing credentials as stored in couchdb into the proper form for the credential store
+    // Except for GCS, which is grandfathered as the default, the result must include a 'provider' field denoting
+    // a valid npm-installable package
+    func prepareCredentials(original: AnyObject) -> StorageKey
+    // Unique identifier for this storage provider, e.g. @nimbella/storage-provider.
+    // Used by factory function to perform dynamic lookups for provider impl at runtime.
+    var identifier: String { get }
+}

--- a/Sources/nimbella-sdk/StorageInterface.swift
+++ b/Sources/nimbella-sdk/StorageInterface.swift
@@ -15,7 +15,7 @@
  */
 
 import Foundation
-import Combine
+import NIO
 
 // Model the StorageKey type that is to be stored in the credential store.  Only the 'provider' member has
 // specified semantics.  The rest is at the convenience of the provider.
@@ -96,19 +96,19 @@ public protocol RemoteFile {
     // The name of the file
     var name: String { get }
     // Save data into the file
-    func save(data: Data, options: SaveOptions) -> Future<Void, Error>
+    func save(data: Data, options: SaveOptions) -> EventLoopFuture<Void>
     // Set the file metadata
-    func setMetadata(meta: SettableFileMetadata) -> Future<Void, Error>
+    func setMetadata(meta: SettableFileMetadata) -> EventLoopFuture<Void>
     // Get the file metadata
-    func getMetadata() -> Future<FileMetadata, Error>
+    func getMetadata() -> EventLoopFuture<FileMetadata>
     // Test whether file exists
-    func exists() -> Future<Bool, Error>
+    func exists() -> EventLoopFuture<Bool>
     // Delete the file
-    func delete() -> Future<Void, Error>
+    func delete() -> EventLoopFuture<Void>
     // Obtain the contents of the file
-    func download(options: DownloadOptions?) -> Future<Data, Error>
+    func download(options: DownloadOptions?) -> EventLoopFuture<Data>
     // Get a signed URL to the file
-    func getSignedUrl(options: SignedUrlOptions) -> Future<String, Error>
+    func getSignedUrl(options: SignedUrlOptions) -> EventLoopFuture<String>
     // Get the underlying implementation for provider-dependent operations
     func getImplementation() -> AnyObject
 }
@@ -118,15 +118,15 @@ public protocol StorageClient {
     // Get the root URL if the client is for web storage (return falsey for data storage)
     func getURL() -> String
     // Set website information
-    func setWebsite(website: WebsiteOptions) -> Future<Void, Error>
+    func setWebsite(website: WebsiteOptions) -> EventLoopFuture<Void>
     // Delete files from the store
-    func deleteFiles(options: DeleteFilesOptions?) -> Future<Void, Error>
+    func deleteFiles(options: DeleteFilesOptions?) -> EventLoopFuture<Void>
     // Add a local file (specified by path)
-    func upload(path: String, options: UploadOptions?) -> Future<Void, Error>
+    func upload(path: String, options: UploadOptions?) -> EventLoopFuture<Void>
     // Obtain a file handle in the store.  The file may or may not exist
     func file(destination: String) -> RemoteFile
     // Get files from the store
-    func getFiles(options: GetFilesOptions?) -> Future<[RemoteFile], Error>
+    func getFiles(options: GetFilesOptions?) -> EventLoopFuture<[RemoteFile]>
     // Get the underlying implementation for provider-dependent operations
     func getImplementation() -> AnyObject
 }

--- a/Tests/nimbella-sdk-tests/Tests.swift
+++ b/Tests/nimbella-sdk-tests/Tests.swift
@@ -1,0 +1,24 @@
+import nimbella_sdk
+import XCTest
+
+class BasicTests : XCTestCase {
+    func testUnimplementedFunctions() {
+        var thrownError: Error?
+        XCTAssertThrowsError(try redis()) {
+            thrownError = $0
+        }
+        XCTAssertTrue(
+          thrownError is NimbellaError,
+          "Error is not NimbellaError"
+        )
+        XCTAssertEqual(thrownError as? NimbellaError, .notImplemented)
+        XCTAssertThrowsError(try storageClient(false)) {
+            thrownError = $0
+        }
+        XCTAssertTrue(
+          thrownError is NimbellaError,
+          "Error is not NimbellaError"
+        )
+        XCTAssertEqual(thrownError as? NimbellaError, .notImplemented)
+    }
+}

--- a/Tests/nimbella-sdk-tests/Tests.swift
+++ b/Tests/nimbella-sdk-tests/Tests.swift
@@ -1,17 +1,26 @@
 import nimbella_sdk
 import XCTest
+import RediStack
 
 class BasicTests : XCTestCase {
-    func testUnimplementedFunctions() {
-        var thrownError: Error?
-        XCTAssertThrowsError(try redis()) {
-            thrownError = $0
+    func testSDK() {
+        // Requires local redis instance to be started and use the indicated password
+        setenv("__NIM_REDIS_IP", "localhost", 1)
+        setenv("__NIM_REDIS_PASSWORD", "3b37b7", 1)
+        self.continueAfterFailure = false
+        do {
+            let redisClient = try redis()
+            try redisClient.set("foo", to: "bar").wait()
+            let result = try redisClient.get("foo").wait()?.string
+            XCTAssertEqual(result, "bar")
+            let deleted = try redisClient.delete(["foo"]).wait()
+            XCTAssertEqual(deleted, 1)
+            let newResult = try redisClient.get("foo").wait()
+            XCTAssertEqual(newResult, nil)
+        } catch {
+            XCTFail("\(error)")
         }
-        XCTAssertTrue(
-          thrownError is NimbellaError,
-          "Error is not NimbellaError"
-        )
-        XCTAssertEqual(thrownError as? NimbellaError, .notImplemented)
+        var thrownError: Error?
         XCTAssertThrowsError(try storageClient(false)) {
             thrownError = $0
         }


### PR DESCRIPTION
As discussed in issue #1.   The plan is to provide a full-function Swift SDK covering both key-value storage and object storage.  This first PR includes
- support for key-value via `RediStack`.  Unit-tested but ...
    - meaningful integration testing is waiting for the Swift runtime to be upgraded
- the interface declaration for object storage but ...
    - there are no storage providers yet (neither S3 nor GCS)
As discussed with @rabbah, the incremental approach seems appropriate as there are a number of moving parts.